### PR TITLE
Fix time formatting

### DIFF
--- a/opaleye-sqlite/src/Opaleye/SQLite/PGTypes.hs
+++ b/opaleye-sqlite/src/Opaleye/SQLite/PGTypes.hs
@@ -98,7 +98,7 @@ pgDay :: Time.Day -> Column PGDate
 pgDay = IPT.unsafePgFormatTime "date" "'%0Y-%m-%d'"
 
 pgUTCTime :: Time.UTCTime -> Column PGTimestamptz
-pgUTCTime = IPT.unsafePgFormatTime "timestamptz" "'%0Y-%m-%dT%T%QZ'"
+pgUTCTime = IPT.unsafePgFormatTime "timestamptz" "'%0Y-%m-%dT%TZ'"
 
 pgLocalTime :: Time.LocalTime -> Column PGTimestamp
 pgLocalTime = IPT.unsafePgFormatTime "timestamp" "'%0Y-%m-%dT%T'"


### PR DESCRIPTION
Reason why this is needed: Postgresql doesn't know how to parse:
`25-10-20T22:36:00Z` because both d-m-y and y-m-d formats could work.
Will add explicit padding to year to make it clear.

The previous format %F is %Y-%m-%d where %Y is unppaded. 

The behaviour is illustrated below:
```
=> select '02-10-20T22:36:00Z' :: timestamp;
  timestamp
  ---------------------
  2020-02-10 22:36:00



=> select '0020-10-20T22:36:00Z' :: timestamp;
  timestamp
  ---------------------
  0020-10-20 22:36:00



=> select '020-10-20T22:36:00Z' :: timestamp;
  timestamp
  ---------------------
  0020-10-20 22:36:00



=> select '20-10-20T22:36:00Z' :: timestamp;
  ERROR:  22008: date/time field value out of range: "20-10-20T22:36:00Z"
  LINE 1: select '20-10-20T22:36:00Z' :: timestamp; ^
  HINT:  Perhaps you need a different "datestyle" setting.
  LOCATION:  DateTimeParseError, datetime.c:3763

=> select '12-10-20T22:36:00Z' :: timestamp;
  timestamp
  ---------------------
  2020-12-10 22:36:00

=> select '25-10-20T22:36:00Z' :: timestamp;
  ERROR:  22008: date/time field value out of range: "25-10-20T22:36:00Z" 
  LINE 1: select '25-10-20T22:36:00Z' :: timestamp;               ^
  HINT:  Perhaps you need a different "datestyle" setting.
  LOCATION:  DateTimeParseError, datetime.c:3763

=> select '020-10-20T22:36:00Z' :: timestamp;
  timestamp
  ---------------------
    0020-10-20 22:36:00
    (1 row)

```