### PR TITLE
Some dates require year padding to be properly parsed by PostgreSQL and SQLite

### DIFF
--- a/opaleye-sqlite/src/Opaleye/SQLite/PGTypes.hs
+++ b/opaleye-sqlite/src/Opaleye/SQLite/PGTypes.hs
@@ -2,22 +2,22 @@
 
 module Opaleye.SQLite.PGTypes (module Opaleye.SQLite.PGTypes) where
 
-import           Opaleye.SQLite.Internal.Column (Column)
-import qualified Opaleye.SQLite.Internal.Column as C
-import qualified Opaleye.SQLite.Internal.PGTypes as IPT
+import           Opaleye.SQLite.Internal.Column                (Column)
+import qualified Opaleye.SQLite.Internal.Column                as C
+import qualified Opaleye.SQLite.Internal.PGTypes               as IPT
 
-import qualified Opaleye.SQLite.Internal.HaskellDB.PrimQuery as HPQ
+import qualified Opaleye.SQLite.Internal.HaskellDB.PrimQuery   as HPQ
 import qualified Opaleye.SQLite.Internal.HaskellDB.Sql.Default as HSD (quote)
 
-import qualified Data.CaseInsensitive as CI
-import qualified Data.Text as SText
-import qualified Data.Text.Lazy as LText
-import qualified Data.ByteString as SByteString
-import qualified Data.ByteString.Lazy as LByteString
-import qualified Data.Time as Time
-import qualified Data.UUID as UUID
+import qualified Data.ByteString                               as SByteString
+import qualified Data.ByteString.Lazy                          as LByteString
+import qualified Data.CaseInsensitive                          as CI
+import qualified Data.Text                                     as SText
+import qualified Data.Text.Lazy                                as LText
+import qualified Data.Time                                     as Time
+import qualified Data.UUID                                     as UUID
 
-import           Data.Int (Int64)
+import           Data.Int                                      (Int64)
 
 data PGBool
 data PGDate
@@ -95,13 +95,13 @@ unsafePgFormatTime = IPT.unsafePgFormatTime
   #-}
 
 pgDay :: Time.Day -> Column PGDate
-pgDay = IPT.unsafePgFormatTime "date" "'%F'"
+pgDay = IPT.unsafePgFormatTime "date" "'%0Y-%m-%d'"
 
 pgUTCTime :: Time.UTCTime -> Column PGTimestamptz
-pgUTCTime = IPT.unsafePgFormatTime "timestamptz" "'%FT%TZ'"
+pgUTCTime = IPT.unsafePgFormatTime "timestamptz" "'%0Y-%m-%dT%TZ'"
 
 pgLocalTime :: Time.LocalTime -> Column PGTimestamp
-pgLocalTime = IPT.unsafePgFormatTime "timestamp" "'%FT%T'"
+pgLocalTime = IPT.unsafePgFormatTime "timestamp" "'%0Y-%m-%dT%T'"
 
 pgTimeOfDay :: Time.TimeOfDay -> Column PGTime
 pgTimeOfDay = IPT.unsafePgFormatTime "time" "'%T'"

--- a/src/Opaleye/Internal/PGTypesExternal.hs
+++ b/src/Opaleye/Internal/PGTypesExternal.hs
@@ -1,32 +1,32 @@
-{-# LANGUAGE EmptyDataDecls #-}
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE EmptyDataDecls       #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 
 module Opaleye.Internal.PGTypesExternal
   (module Opaleye.Internal.PGTypesExternal, IsSqlType(..)) where
 
-import           Opaleye.Internal.Column (Column)
-import qualified Opaleye.Internal.Column as C
-import qualified Opaleye.Internal.PGTypes as IPT
-import           Opaleye.Internal.PGTypes (IsSqlType(..))
+import           Opaleye.Internal.Column                (Column)
+import qualified Opaleye.Internal.Column                as C
+import           Opaleye.Internal.PGTypes               (IsSqlType (..))
+import qualified Opaleye.Internal.PGTypes               as IPT
 
-import qualified Opaleye.Internal.HaskellDB.PrimQuery as HPQ
+import qualified Opaleye.Internal.HaskellDB.PrimQuery   as HPQ
 import qualified Opaleye.Internal.HaskellDB.Sql.Default as HSD
 
-import qualified Data.CaseInsensitive as CI
-import qualified Data.Aeson as Ae
-import qualified Data.Text as SText
-import qualified Data.Text.Lazy as LText
-import qualified Data.ByteString as SByteString
-import qualified Data.ByteString.Lazy as LByteString
-import           Data.Scientific as Sci
-import qualified Data.Time.Compat as Time
-import qualified Data.Time.Format.ISO8601.Compat as Time.Format.ISO8601
-import qualified Data.UUID as UUID
+import qualified Data.Aeson                             as Ae
+import qualified Data.ByteString                        as SByteString
+import qualified Data.ByteString.Lazy                   as LByteString
+import qualified Data.CaseInsensitive                   as CI
+import           Data.Scientific                        as Sci
+import qualified Data.Text                              as SText
+import qualified Data.Text.Lazy                         as LText
+import qualified Data.Time.Compat                       as Time
+import qualified Data.Time.Format.ISO8601.Compat        as Time.Format.ISO8601
+import qualified Data.UUID                              as UUID
 
-import           Data.Int (Int64)
+import           Data.Int                               (Int64)
 
-import qualified Database.PostgreSQL.Simple.Range as R
+import qualified Database.PostgreSQL.Simple.Range       as R
 
 instance C.SqlNum SqlFloat8 where
   sqlFromInteger = pgDouble . fromInteger
@@ -102,16 +102,16 @@ pgUUID :: UUID.UUID -> Column PGUuid
 pgUUID = IPT.literalColumn . HPQ.StringLit . UUID.toString
 
 pgDay :: Time.Day -> Column PGDate
-pgDay = IPT.unsafePgFormatTime "date" "'%F'"
+pgDay = IPT.unsafePgFormatTime "date" "'%0Y-%m-%d'"
 
 pgUTCTime :: Time.UTCTime -> Column PGTimestamptz
-pgUTCTime = IPT.unsafePgFormatTime "timestamptz" "'%FT%T%QZ'"
+pgUTCTime = IPT.unsafePgFormatTime "timestamptz" "'%0Y-%m-%dT%T%QZ'"
 
 pgLocalTime :: Time.LocalTime -> Column PGTimestamp
-pgLocalTime = IPT.unsafePgFormatTime "timestamp" "'%FT%T%Q'"
+pgLocalTime = IPT.unsafePgFormatTime "timestamp" "'%0Y-%m-%dT%T%Q'"
 
 pgZonedTime :: Time.ZonedTime -> Column PGTimestamptz
-pgZonedTime = IPT.unsafePgFormatTime "timestamptz" "'%FT%T%Q%z'"
+pgZonedTime = IPT.unsafePgFormatTime "timestamptz" "'%0Y-%m-%dT%T%Q%z'"
 
 pgTimeOfDay :: Time.TimeOfDay -> Column PGTime
 pgTimeOfDay = IPT.unsafePgFormatTime "time" "'%T%Q'"


### PR DESCRIPTION
Reason why this is needed: Postgresql doesn't know how to parse:
`25-10-20T22:36:00Z` because both d-m-y and y-m-d formats could work.
Will add explicit padding to year to make it clear.

The previous format %F is %Y-%m-%d where %Y is unppaded. 

The behaviour is illustrated below:
```
=> select '02-10-20T22:36:00Z' :: timestamp;
  timestamp
  ---------------------
  2020-02-10 22:36:00



=> select '0020-10-20T22:36:00Z' :: timestamp;
  timestamp
  ---------------------
  0020-10-20 22:36:00



=> select '020-10-20T22:36:00Z' :: timestamp;
  timestamp
  ---------------------
  0020-10-20 22:36:00



=> select '20-10-20T22:36:00Z' :: timestamp;
  ERROR:  22008: date/time field value out of range: "20-10-20T22:36:00Z"
  LINE 1: select '20-10-20T22:36:00Z' :: timestamp; ^
  HINT:  Perhaps you need a different "datestyle" setting.
  LOCATION:  DateTimeParseError, datetime.c:3763

=> select '12-10-20T22:36:00Z' :: timestamp;
  timestamp
  ---------------------
  2020-12-10 22:36:00

=> select '25-10-20T22:36:00Z' :: timestamp;
  ERROR:  22008: date/time field value out of range: "25-10-20T22:36:00Z" 
  LINE 1: select '25-10-20T22:36:00Z' :: timestamp;               ^
  HINT:  Perhaps you need a different "datestyle" setting.
  LOCATION:  DateTimeParseError, datetime.c:3763

=> select '020-10-20T22:36:00Z' :: timestamp;
  timestamp
  ---------------------
    0020-10-20 22:36:00
    (1 row)

```